### PR TITLE
Fix inaccurate lower bound on base

### DIFF
--- a/shortcut.cabal
+++ b/shortcut.cabal
@@ -16,7 +16,7 @@ data-dir: ""
 extra-source-files: AUTHORS README.md
 
 library
-    build-depends: base               >= 4.6 && < 5
+    build-depends: base               >= 4.8 && < 5
     exposed-modules: Control.Shortcut
     exposed: True
     buildable: True


### PR DESCRIPTION
With base-4.6 & base-4.7 the following compile error occurs:

```
Configuring library for shortcut-0.1..
Preprocessing library for shortcut-0.1..
Building library for shortcut-0.1..
[1 of 1] Compiling Control.Shortcut ( src/Control/Shortcut.hs, dist/build/Control/Shortcut.o )

src/Control/Shortcut.hs:16:28: Not in scope: ‘<$>’

src/Control/Shortcut.hs:21:42: Not in scope: ‘<$>’

src/Control/Shortcut.hs:22:43: Not in scope: ‘<$>’

src/Control/Shortcut.hs:24:32: Not in scope: ‘<$>’

src/Control/Shortcut.hs:24:56: Not in scope: ‘<$>’
```